### PR TITLE
Generate cluster for each Redis database + Use Deliveroo's fork of Twemproxy

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,7 @@ set -e
 unset GIT_DIR
 
 # config
-TWEMPROXY_VERSION="0.4.1"
+TWEMPROXY_VERSION="0.4.2"
 
 # parse and derive params
 BUILD_DIR=$1

--- a/bin/gen-twemproxy-conf.sh
+++ b/bin/gen-twemproxy-conf.sh
@@ -20,6 +20,8 @@ do
 
   i=0
 
+  export TWEMPROXY_CONFIG_GENERATED="1"
+
   while [ $i -lt 16 ]; do
     port=""
 
@@ -42,7 +44,7 @@ ${_REDIS_URL}_${i}:
   redis_db: ${i}
   servers:
    - ${DB_HOST}:${DB_PORT}:1
-  timeout: 30000
+  timeout: 5000
 EOFEOF
 
     let "i += 1"

--- a/bin/gen-twemproxy-conf.sh
+++ b/bin/gen-twemproxy-conf.sh
@@ -20,8 +20,6 @@ do
 
   i=0
 
-  export TWEMPROXY_CONFIG_GENERATED="1"
-
   while [ $i -lt 16 ]; do
     port=""
 

--- a/bin/gen-twemproxy-conf.sh
+++ b/bin/gen-twemproxy-conf.sh
@@ -24,7 +24,7 @@ do
     port=""
 
     if [ $i -lt 10 ]; then
-      port="$62${n}0${i}"
+      port="62${n}0${i}"
     else
       port="62${n}${i}"
     fi

--- a/bin/twemproxy-build
+++ b/bin/twemproxy-build
@@ -5,7 +5,7 @@ set -e
 
 cd $BUILD_DIR/
 if [ ! -f $BUILD_DIR/twemproxy-$TWEMPROXY_VERSION.tar.gz ]; then
-  wget -q -O $BUILD_DIR/twemproxy-$TWEMPROXY_VERSION.tar.gz https://github.com/twitter/twemproxy/archive/v$TWEMPROXY_VERSION.tar.gz
+  wget -q -O $BUILD_DIR/twemproxy-$TWEMPROXY_VERSION.tar.gz https://github.com/deliveroo/twemproxy/archive/v$TWEMPROXY_VERSION.tar.gz
 fi
 
 tar zxf $BUILD_DIR/twemproxy-$TWEMPROXY_VERSION.tar.gz


### PR DESCRIPTION
The existing configuration generator generates one cluster for each Redis instance and it uses the default database of 0. Due to the limitation of Twemproxy presents itself as database 0 all the time, we need to update the configuration generation script to create a cluster for each db, so from the application point of view we can easily select which one we want to use.

Other thing it does is making the buildpack using our version of Twemproxy, which has a patch that gets `redis_auth` and `redis_db` working together. Without this patch, we can't use Twemproxy as we have usage of different DBs in orderweb codebase.

For the actual reasoning behind the changes, I can provide you the write-up via DM as the document contains confidential stuff in it.